### PR TITLE
Adds attributes parameter to visit() and attributes() method for public use

### DIFF
--- a/projects/lib/src/lib/ackee.interfaces.ts
+++ b/projects/lib/src/lib/ackee.interfaces.ts
@@ -25,6 +25,7 @@ export interface AckeeTracker {
       detailed?: boolean;
     }
   ) => AckeeInstance;
+  attributes: (detailed: boolean) => AckeeAttributesObject;
 }
 
 export interface AckeeInstance {

--- a/projects/lib/src/lib/ackee.service.ts
+++ b/projects/lib/src/lib/ackee.service.ts
@@ -28,7 +28,7 @@ export class AckeeService {
     await this.load();
 
     if (!attributes)
-      attributes = window.ackeeTracker.attributes(this.ackeeConfig.options.detailed ?? false);
+      attributes = this.ackeeAttributes;
 
     this.track(attributes);
     if (obs) {


### PR DESCRIPTION
Useful when the user wants to manipulate the attributes when calling `Visit()`. For Electron apps, etc.